### PR TITLE
fix(PAGE_VISIBILITY): share replay of page visibility

### DIFF
--- a/projects/common/package.json
+++ b/projects/common/package.json
@@ -3,7 +3,8 @@
     "version": "2.0.0",
     "peerDependencies": {
         "@angular/common": ">=12.0.0",
-        "@angular/core": ">=12.0.0"
+        "@angular/core": ">=12.0.0",
+        "rxjs": ">=6.4.0"
     },
     "description": "A set of common utils for consuming Web APIs with Angular",
     "keywords": ["angular", "ng", "window", "api", "web api", "navigator", "user agent"],

--- a/projects/common/src/tokens/page-visibility.ts
+++ b/projects/common/src/tokens/page-visibility.ts
@@ -1,7 +1,7 @@
 import {DOCUMENT} from '@angular/common';
 import {inject, InjectionToken} from '@angular/core';
 import {fromEvent, Observable} from 'rxjs';
-import {distinctUntilChanged, map, share, startWith} from 'rxjs/operators';
+import {distinctUntilChanged, map, shareReplay, startWith} from 'rxjs/operators';
 
 export const PAGE_VISIBILITY = new InjectionToken<Observable<boolean>>(
     'Shared Observable based on `document visibility changed`',
@@ -13,7 +13,7 @@ export const PAGE_VISIBILITY = new InjectionToken<Observable<boolean>>(
                 startWith(0),
                 map(() => documentRef.visibilityState !== 'hidden'),
                 distinctUntilChanged(),
-                share(),
+                shareReplay({refCount: false, bufferSize: 1}),
             );
         },
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

When the PAGE_VISIBILITY stream has more than one subscriber, all subscribers after the first will not get a value until the stream fires again (upon leaving and re-entering the page).

Issue Number:  #44

## What is the new behavior?

All subscribers of PAGE_VISIBILITY will get the most recent value upon subscription.  

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No


## Other information

This could also be fixed by removing the `share` operator from the end of the pipe, but `shareReplay` stops the side effects from running more than once. 